### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/lib/Net/Fastly/Client.pm
+++ b/lib/Net/Fastly/Client.pm
@@ -202,7 +202,7 @@ sub _delete {
 sub _headers {
     my $self   = shift;
     my $extras = shift;
-    my $params = $self->fully_authed ? { 'Cookie' => $self->{_cookie} } : { 'X-Fastly-Key' => $self->{api_key} };
+    my $params = $self->fully_authed ? { 'Cookie' => $self->{_cookie} } : { 'Fastly-Key' => $self->{api_key} };
     $params->{'Fastly-Explicit-Customer'} = $self->{explicit_customer} if defined $self->{explicit_customer};
     $params->{'Content-Accept'} =  'application/json';
     $params->{'User-Agent'} =  "fastly-perl-v$Net::Fastly::VERSION";


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.