### PR TITLE
Make fastly use $ENV{USERPROFILE} not $ENV{HOME} on Windows

### DIFF
--- a/bin/fastly
+++ b/bin/fastly
@@ -66,14 +66,15 @@ or in CSH or TCSH
 
 =cut
 
-my %opts   = Net::Fastly::get_options($ENV{HOME}."/.fastly", "/etc/fastly");
+my $homedir = ($^O eq 'MSWin32') ? $ENV{USERPROFILE} : $ENV{HOME} ;
+my %opts   = Net::Fastly::get_options($homedir."/.fastly", "/etc/fastly");
 my $fastly = Net::Fastly->new(%opts);
 
 my $customer = $fastly->current_customer;
 
 
 
-my $term = Term::ShellUI->new(app => "fastly", keep_quotes => 0,  history_file => $ENV{HOME}."/.fastly_history", prompt => "fastly> ");
+my $term = Term::ShellUI->new(app => "fastly", keep_quotes => 0,  history_file => $homedir."/.fastly_history", prompt => "fastly> ");
           
 #$term->{debug_complete}=5;
  


### PR DESCRIPTION
Windows doesn't have _$ENV{HOME}_ (under default conditions) and so running **_fastly_** on Windows fails . This commit makes _**fastly**_ use _$ENV{USERPROFILE}_, which exists by default, on Windows instead.

PS New keyboard is my excuse for typos in the commit message. ;-)