### PR TITLE
CI to automatically publish to CPAN

### DIFF
--- a/.github/scripts/pack.sh
+++ b/.github/scripts/pack.sh
@@ -1,0 +1,25 @@
+# mark version
+sed -i "s/^use constant VERSION => .*$/use constant VERSION => '${VERSION}';/" ./lib/WebService/Fastly/Configuration.pm
+sed -i "s/^our \$VERSION = .*$/our \$VERSION = '${VERSION}';/" ./lib/WebService/Fastly.pm
+
+# make a package (output is current directory)
+TRIAL=""
+if [ "${TRIAL_ID}" != "" ]; then
+  TRIAL="--trial"
+fi
+milla build ${TRIAL}
+
+# save the output filename to env
+ARTIFACT_FILENAME=$(ls -1 -- WebService-Fastly-*.tar.gz)
+if [ "${TRIAL_ID}" != "" ]; then
+  # Currently looks like WebService-Fastly-x.yyy-TRIAL.tar.gz
+  PACKAGE_FILENAME="${ARTIFACT_FILENAME%.tar.gz}${TRIAL_ID}.tar.gz"
+  # Now looks like WebService-Fastly-x.yyy-TRIALz.tar.gz
+else
+  PACKAGE_FILENAME="${ARTIFACT_FILENAME}"
+fi
+echo "PACKAGE_FILENAME=${PACKAGE_FILENAME}" >> "${GITHUB_ENV}"
+
+# move package to dist
+mkdir -p "${GITHUB_WORKSPACE}/dist"
+mv "${ARTIFACT_FILENAME}" "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}"

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,0 +1,11 @@
+echo "Publishing ${PROJECT_NAME} to ${PACKAGE_REPO_NAME}"
+echo " Publishing version: ${VERSION}"
+echo " Publish tag is ${PUBLISH_TAG}"
+
+# perform publish
+if [ "${DRY_RUN}" == "1" ]; then
+  echo "(dry run)"
+  # Don't actually call cpan-upload --dry-run, because it echoes the password
+else
+  cpan-upload "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}"
+fi

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -20,12 +20,12 @@ fi
 
 # fastly-perl versions are either x.yyy or x.yyy-"trial"z
 VERSION_PURE="${VERSION%-trial*([0-9])}"
-echo "VERSION=${VERSION}"
-echo "VERSION_PURE=${VERSION_PURE}"
+VERSION_TITLE="v${VERSION}"
 if [ "${VERSION}" != "${VERSION_PURE}" ]; then
   TRIAL_ID="${VERSION#${VERSION_PURE}-trial}"
   VERSION="${VERSION_PURE}"
   PUBLISH_TAG=trial
+  VERSION_TITLE="v${VERSION}-TRIAL${TRIAL_ID}"
 fi
 PUBLISH_TAG="${PUBLISH_TAG:-latest}"
 
@@ -33,6 +33,7 @@ echo "API_CLIENT_NAME=Perl"
 echo "PROJECT_NAME=fastly-php"
 echo "PACKAGE_REPO_NAME=CPAN"
 echo "VERSION=${VERSION}"
+echo "VERSION_TITLE=${VERSION_TITLE}"
 echo "DRY_RUN=${DRY_RUN}"
 echo "PUBLISH_TAG=${PUBLISH_TAG}"
 echo "TRIAL_ID=${TRIAL_ID}"

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,0 +1,38 @@
+# Use bash extglob
+shopt -s extglob
+
+# Parse the release tag
+
+# strip leading 'release/'
+TAG="${GITHUB_REF_NAME#release/}"
+
+# strip leading v
+TAG_VALUE="${TAG#v}"
+
+# strip trailing -dry
+VERSION="${TAG_VALUE%-dry}"
+
+# Detect dry run mode
+DRY_RUN=0
+if [ "${TAG_VALUE}" != "${VERSION}" ]; then
+    DRY_RUN=1
+fi
+
+# fastly-perl versions are either x.yyy or x.yyy-"trial"z
+VERSION_PURE="${VERSION%-trial*([0-9])}"
+echo "VERSION=${VERSION}"
+echo "VERSION_PURE=${VERSION_PURE}"
+if [ "${VERSION}" != "${VERSION_PURE}" ]; then
+  TRIAL_ID="${VERSION#${VERSION_PURE}-trial}"
+  VERSION="${VERSION_PURE}"
+  PUBLISH_TAG=trial
+fi
+PUBLISH_TAG="${PUBLISH_TAG:-latest}"
+
+echo "API_CLIENT_NAME=Perl"
+echo "PROJECT_NAME=fastly-php"
+echo "PACKAGE_REPO_NAME=CPAN"
+echo "VERSION=${VERSION}"
+echo "DRY_RUN=${DRY_RUN}"
+echo "PUBLISH_TAG=${PUBLISH_TAG}"
+echo "TRIAL_ID=${TRIAL_ID}"

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -30,7 +30,7 @@ fi
 PUBLISH_TAG="${PUBLISH_TAG:-latest}"
 
 echo "API_CLIENT_NAME=Perl"
-echo "PROJECT_NAME=fastly-php"
+echo "PROJECT_NAME=fastly-perl"
 echo "PACKAGE_REPO_NAME=CPAN"
 echo "VERSION=${VERSION}"
 echo "VERSION_TITLE=${VERSION_TITLE}"

--- a/.github/scripts/release_body.sh
+++ b/.github/scripts/release_body.sh
@@ -1,0 +1,25 @@
+printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION}"
+
+if [ "${DRY_RUN}" == "1" ]; then
+  printf '%s' " (dry run)"
+fi
+
+echo ""
+
+# add a newline
+echo ""
+
+CODE_PATH=${CODE_PATH:-./}
+G_CODE=$(jq -r .G "${CODE_PATH}/sig.json")
+D_CODE=$(jq -r .D "${CODE_PATH}/sig.json")
+
+PACKAGE_FILESIZE=$(ls -lh "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}" | awk '{print $5}')B
+
+echo "Artifact"
+echo " ${PACKAGE_FILENAME} (${PACKAGE_FILESIZE})"
+echo ""
+echo "Generated on: $(date)"
+echo "G-code: ${G_CODE}, D-code: ${D_CODE}"
+if [ "${PUBLISH_TAG}" != "latest" ]; then
+  echo "Pre-release Tag: ${PUBLISH_TAG}"
+fi

--- a/.github/scripts/release_body.sh
+++ b/.github/scripts/release_body.sh
@@ -1,4 +1,4 @@
-printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION}"
+printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION_TITLE}"
 
 if [ "${DRY_RUN}" == "1" ]; then
   printf '%s' " (dry run)"
@@ -21,5 +21,5 @@ echo ""
 echo "Generated on: $(date)"
 echo "G-code: ${G_CODE}, D-code: ${D_CODE}"
 if [ "${PUBLISH_TAG}" != "latest" ]; then
-  echo "Pre-release Tag: ${PUBLISH_TAG}"
+  echo "Pre-release Tag: ${PUBLISH_TAG} ${TRIAL_ID}"
 fi

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,0 +1,62 @@
+name: Release CI
+on:
+  push:
+    tags:
+      # This looks like a regex, but it's actually a filter pattern
+      # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - 'release/v?[0-9]+.[0-9]+'
+      - 'release/v?[0-9]+.[0-9]+-dry'
+      - 'release/v?[0-9]+.[0-9]+-trial[0-9]+'
+      - 'release/v?[0-9]+.[0-9]+-trial[0-9]+-dry'
+
+env:
+  GITHUB_REF_NAME: ${{ github.ref_name }}
+
+jobs:
+  publish:
+    name: Publish to CPAN
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Set up environment variables
+        run: ./.github/scripts/publish_env.sh >> $GITHUB_ENV
+        working-directory: ./main
+        shell: bash
+      - name: Setup cpanm, milla, and cpan-upload
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          install: |
+            Dist::Milla
+            CPAN::Uploader
+      - name: Pack API client
+        run: ./.github/scripts/pack.sh
+        working-directory: ./main
+        shell: bash
+      - name: Auth with CPAN
+        run: |
+          echo "user FASTLY" > ~/.pause
+          echo "password ${{ secrets.CPAN_PUBLISH_TOKEN }}" >> ~/.pause
+        shell: bash
+      - name: Publish API client
+        run: ./.github/scripts/publish.sh
+        working-directory: ./main
+        shell: bash
+      - name: Write release body file
+        run: CODE_PATH=./main ./main/.github/scripts/release_body.sh > ./dist/release_body.txt
+        shell: bash
+      - name: Create release (dry run)
+        if: ${{ env.DRY_RUN == '1' }}
+        run: cat ./dist/release_body.txt
+      - name: Create GitHub release
+        if: ${{ env.DRY_RUN != '1' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.VERSION }}
+          body_path: ./dist/release_body.txt
+          files: |
+            ./dist/${{ env.PACKAGE_FILENAME }}
+          draft: false
+          prerelease: ${{ env.PUBLISH_TAG != 'latest' }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ env.DRY_RUN != '1' }}
         uses: softprops/action-gh-release@v1
         with:
-          name: v${{ env.VERSION }}
+          name: v${{ env.VERSION_TITLE }}
           body_path: ./dist/release_body.txt
           files: |
             ./dist/${{ env.PACKAGE_FILENAME }}


### PR DESCRIPTION
This PR adds a publish mechanism to allow this API client to publish itself to CPAN and create a release in GitHub.

The input is to create a tag in this repo and push it, with the syntax: `release/[VERSION][-dry]`.

- `VERSION` should be the version number that the package should be published under, such as `v3.01` or `3.01-trial1` (leading `v` is optional and ignored)
  - version must be specified as x.yyy format (not x.yyy.zzz)
  - `trial` (all lower case) followed by a number can be specified for prerelease versions
- Specify `-dry` if you want to do a "dry run" which doesn't actually publish to CPAN or create a release

This CI is intended to be used along with the client generator project, whose job it is to generate the newest API client code, tag it with said version code, and push it to this repo.

Unless running in `-dry` mode, this CI step will create a real version in CPAN, and a release in GitHub. Example run using `release/v2.02-trial2` has generated the following:
 - CI run: https://github.com/fastly/fastly-perl/actions/runs/3702887230
 - CPAN release (metacpan): https://metacpan.org/release/FASTLY/WebService-Fastly-2.02-TRIAL2/view/lib/WebService/Fastly.pm
   - If the version number contains trial, then it is tagged in CPAN as a development release.
 - GitHub release: https://github.com/fastly/fastly-perl/releases/tag/release%2Fv2.02-trial2
 - Artifact (node package tarball): https://github.com/fastly/fastly-perl/releases/download/release%2Fv2.02-trial2/WebService-Fastly-2.02-TRIAL2.tar.gz
   - Note the artifact is added to the GitHub release as a release asset

If running in `-dry` mode, no actual CPAN publish or release will be made. Example run using `release/v2.02-trial2-dry`:
 - CI run: https://github.com/fastly/fastly-perl/actions/runs/3702887248
   - Click through this link into the "Publish to CPAN" job, and read the output of the "Create Release (Dry Run)" step. You'll see the following output:
      ```
      ## Perl API client v2.02 (dry run)
      
      Artifact
       WebService-Fastly-2.02-TRIAL2.tar.gz (505KB)
      
      Generated on: Thu Dec 15 09:46:48 UTC 2022
      G-code: 8ebeb6c0, D-code: 2a032d6f
      Pre-release Tag: trial
      ```

This CI relies on a PAUSE password for the FASTLY account. This token is stored as a repository secret under the name `CPAN_PUBLISH_TOKEN`.