### PR TITLE
fix(ci): prevent double vv

### DIFF
--- a/.github/scripts/release_body.sh
+++ b/.github/scripts/release_body.sh
@@ -1,4 +1,4 @@
-printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION_TITLE}"
+printf '%s' "## ${API_CLIENT_NAME} API client ${VERSION_TITLE}"
 
 if [ "${DRY_RUN}" == "1" ]; then
   printf '%s' " (dry run)"

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ env.DRY_RUN != '1' }}
         uses: softprops/action-gh-release@v1
         with:
-          name: v${{ env.VERSION_TITLE }}
+          name: ${{ env.VERSION_TITLE }}
           body_path: ./dist/release_body.txt
           files: |
             ./dist/${{ env.PACKAGE_FILENAME }}


### PR DESCRIPTION
`VERSION_TITLE` is defined in `.github/scripts/publish_env.sh` with the `v` prefix already applied, so there was no need to include that in the `.github/scripts/release_body.sh` script or `.github/workflows/ci-release.yaml` release step.

<img width="383" alt="Screenshot 2023-03-23 at 11 36 19" src="https://user-images.githubusercontent.com/180050/227191947-0b64b43b-244e-4983-97e0-f172111f37f0.png">
