### PR TITLE
Set up perl-actions/install-with-cpanm to use MetaCPAN

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -31,6 +31,10 @@ jobs:
           install: |
             Dist::Milla
             CPAN::Uploader
+          args: >-
+            --mirror https://cpan.metacpan.org
+            --mirror-only
+            --verbose
       - name: Pack API client
         run: ./.github/scripts/pack.sh
         working-directory: ./main


### PR DESCRIPTION
This PR updates the Perl build to use the HTTPS metacpan mirror only, this is supposed to produce more reliable and reproducible results.